### PR TITLE
Support for enumeration

### DIFF
--- a/src/main/scala/pbdirect/Enum.scala
+++ b/src/main/scala/pbdirect/Enum.scala
@@ -1,0 +1,28 @@
+package pbdirect
+
+import shapeless.{ :+:, CNil, Coproduct, Generic, Witness }
+
+object Enum {
+  def values[T](implicit v: Values[T], ord: Ordering[T]): Seq[T] = v.apply.sorted
+  def fromInt[T](index: Int)(implicit v: Values[T], ord: Ordering[T]): T = values.apply(index - 1)
+  def toInt[T](a: T)(implicit v: Values[T], ord: Ordering[T]): Int = values.indexOf(a) + 1
+
+  trait Values[T] {
+    def apply: List[T]
+  }
+
+  object Values {
+    implicit def values[A, Repr <: Coproduct](implicit gen: Generic.Aux[A, Repr], v: Aux[A, Repr]): Values[A] =
+      new Values[A] { def apply = v.values }
+
+    trait Aux[A, Repr] {
+      def values: List[A]
+    }
+
+    object Aux {
+      implicit def cnilAux[E]: Aux[E, CNil] = new Aux[E, CNil] { def values = Nil }
+      implicit def cconsAux[E, V <: E, R <: Coproduct](implicit l: Witness.Aux[V], r: Aux[E, R]): Aux[E, V :+: R] =
+        new Aux[E, V :+: R] { def values = l.value :: r.values }
+    }
+  }
+}

--- a/src/main/scala/pbdirect/PBReader.scala
+++ b/src/main/scala/pbdirect/PBReader.scala
@@ -107,6 +107,14 @@ trait PBReaderImplicits extends LowPriorityPBReaderImplicits {
       override def read(index: Int, bytes: Array[Byte]): Map[K, V] =
         reader.read(index, bytes).toMap
     }
+  implicit def enumReader[A](implicit
+    values: Enum.Values[A],
+    ordering: Ordering[A],
+    reader: PBReader[List[Int]]
+  ): PBReader[List[A]] = new PBReader[List[A]] {
+    override def read(index: Int, bytes: Array[Byte]): List[A] =
+      reader.read(index, bytes).map(i => Enum.fromInt(i))
+  }
 }
 
 object PBReader extends PBReaderImplicits

--- a/src/main/scala/pbdirect/PBWriter.scala
+++ b/src/main/scala/pbdirect/PBWriter.scala
@@ -87,6 +87,11 @@ trait PBWriterImplicits extends LowPriorityPBWriterImplicits {
       override def writeTo(index: Int, value: Map[K, V], out: CodedOutputStream) =
         writer.writeTo(index, value.toList, out)
     }
+  implicit def enumWriter[E](implicit values: Enum.Values[E], ordering: Ordering[E]): PBWriter[E] =
+    new PBWriter[E] {
+      override def writeTo(index: Int, value: E, out: CodedOutputStream): Unit =
+        out.writeInt32(index, Enum.toInt(value))
+    }
 }
 
 object PBWriter extends PBWriterImplicits

--- a/src/main/scala/pbdirect/Pos.scala
+++ b/src/main/scala/pbdirect/Pos.scala
@@ -9,6 +9,7 @@ object Pos {
     override def compare(x: P, y: P): Int = x._pos - y._pos
   }
 
+  trait _0 extends Pos { override val _pos = 0 }
   trait _1 extends Pos { override val _pos = 1 }
   trait _2 extends Pos { override val _pos = 2 }
   trait _3 extends Pos { override val _pos = 3 }

--- a/src/main/scala/pbdirect/Pos.scala
+++ b/src/main/scala/pbdirect/Pos.scala
@@ -1,0 +1,111 @@
+package pbdirect
+
+trait Pos {
+  val _pos: Int
+}
+
+object Pos {
+  implicit def posOrdering[P <: Pos]: Ordering[P] = new Ordering[P] {
+    override def compare(x: P, y: P): Int = x._pos - y._pos
+  }
+
+  trait _1 extends Pos { override val _pos = 1 }
+  trait _2 extends Pos { override val _pos = 2 }
+  trait _3 extends Pos { override val _pos = 3 }
+  trait _4 extends Pos { override val _pos = 4 }
+  trait _5 extends Pos { override val _pos = 5 }
+  trait _6 extends Pos { override val _pos = 6 }
+  trait _7 extends Pos { override val _pos = 7 }
+  trait _8 extends Pos { override val _pos = 8 }
+  trait _9 extends Pos { override val _pos = 9 }
+  trait _10 extends Pos { override val _pos = 10 }
+  trait _11 extends Pos { override val _pos = 11 }
+  trait _12 extends Pos { override val _pos = 12 }
+  trait _13 extends Pos { override val _pos = 13 }
+  trait _14 extends Pos { override val _pos = 14 }
+  trait _15 extends Pos { override val _pos = 15 }
+  trait _16 extends Pos { override val _pos = 16 }
+  trait _17 extends Pos { override val _pos = 17 }
+  trait _18 extends Pos { override val _pos = 18 }
+  trait _19 extends Pos { override val _pos = 19 }
+  trait _20 extends Pos { override val _pos = 20 }
+  trait _21 extends Pos { override val _pos = 21 }
+  trait _22 extends Pos { override val _pos = 22 }
+  trait _23 extends Pos { override val _pos = 23 }
+  trait _24 extends Pos { override val _pos = 24 }
+  trait _25 extends Pos { override val _pos = 25 }
+  trait _26 extends Pos { override val _pos = 26 }
+  trait _27 extends Pos { override val _pos = 27 }
+  trait _28 extends Pos { override val _pos = 28 }
+  trait _29 extends Pos { override val _pos = 29 }
+  trait _30 extends Pos { override val _pos = 30 }
+  trait _31 extends Pos { override val _pos = 31 }
+  trait _32 extends Pos { override val _pos = 32 }
+  trait _33 extends Pos { override val _pos = 33 }
+  trait _34 extends Pos { override val _pos = 34 }
+  trait _35 extends Pos { override val _pos = 35 }
+  trait _36 extends Pos { override val _pos = 36 }
+  trait _37 extends Pos { override val _pos = 37 }
+  trait _38 extends Pos { override val _pos = 38 }
+  trait _39 extends Pos { override val _pos = 39 }
+  trait _40 extends Pos { override val _pos = 40 }
+  trait _41 extends Pos { override val _pos = 41 }
+  trait _42 extends Pos { override val _pos = 42 }
+  trait _43 extends Pos { override val _pos = 43 }
+  trait _44 extends Pos { override val _pos = 44 }
+  trait _45 extends Pos { override val _pos = 45 }
+  trait _46 extends Pos { override val _pos = 46 }
+  trait _47 extends Pos { override val _pos = 47 }
+  trait _48 extends Pos { override val _pos = 48 }
+  trait _49 extends Pos { override val _pos = 49 }
+  trait _50 extends Pos { override val _pos = 50 }
+  trait _51 extends Pos { override val _pos = 51 }
+  trait _52 extends Pos { override val _pos = 52 }
+  trait _53 extends Pos { override val _pos = 53 }
+  trait _54 extends Pos { override val _pos = 54 }
+  trait _55 extends Pos { override val _pos = 55 }
+  trait _56 extends Pos { override val _pos = 56 }
+  trait _57 extends Pos { override val _pos = 57 }
+  trait _58 extends Pos { override val _pos = 58 }
+  trait _59 extends Pos { override val _pos = 59 }
+  trait _60 extends Pos { override val _pos = 60 }
+  trait _61 extends Pos { override val _pos = 61 }
+  trait _62 extends Pos { override val _pos = 62 }
+  trait _63 extends Pos { override val _pos = 63 }
+  trait _64 extends Pos { override val _pos = 64 }
+  trait _65 extends Pos { override val _pos = 65 }
+  trait _66 extends Pos { override val _pos = 66 }
+  trait _67 extends Pos { override val _pos = 67 }
+  trait _68 extends Pos { override val _pos = 68 }
+  trait _69 extends Pos { override val _pos = 69 }
+  trait _70 extends Pos { override val _pos = 70 }
+  trait _71 extends Pos { override val _pos = 71 }
+  trait _72 extends Pos { override val _pos = 72 }
+  trait _73 extends Pos { override val _pos = 73 }
+  trait _74 extends Pos { override val _pos = 74 }
+  trait _75 extends Pos { override val _pos = 75 }
+  trait _76 extends Pos { override val _pos = 76 }
+  trait _77 extends Pos { override val _pos = 77 }
+  trait _78 extends Pos { override val _pos = 78 }
+  trait _79 extends Pos { override val _pos = 79 }
+  trait _80 extends Pos { override val _pos = 80 }
+  trait _81 extends Pos { override val _pos = 81 }
+  trait _82 extends Pos { override val _pos = 82 }
+  trait _83 extends Pos { override val _pos = 83 }
+  trait _84 extends Pos { override val _pos = 84 }
+  trait _85 extends Pos { override val _pos = 85 }
+  trait _86 extends Pos { override val _pos = 86 }
+  trait _87 extends Pos { override val _pos = 87 }
+  trait _88 extends Pos { override val _pos = 88 }
+  trait _89 extends Pos { override val _pos = 89 }
+  trait _90 extends Pos { override val _pos = 90 }
+  trait _91 extends Pos { override val _pos = 91 }
+  trait _92 extends Pos { override val _pos = 92 }
+  trait _93 extends Pos { override val _pos = 93 }
+  trait _94 extends Pos { override val _pos = 94 }
+  trait _95 extends Pos { override val _pos = 95 }
+  trait _96 extends Pos { override val _pos = 96 }
+  trait _97 extends Pos { override val _pos = 97 }
+  trait _98 extends Pos { override val _pos = 98 }
+  trait _99 extends Pos { override val _pos = 99 }
+}

--- a/src/test/scala/pbdirect/EnumSpec.scala
+++ b/src/test/scala/pbdirect/EnumSpec.scala
@@ -26,7 +26,7 @@ class EnumSpec extends WordSpecLike with Matchers {
       Enum.toInt[WeekDay](Saturday)  shouldBe 6
       Enum.toInt[WeekDay](Sunday)    shouldBe 7
     }
-    "get the correct value for a position" in {
+    "get correct value for a position" in {
       Enum.fromInt[WeekDay](1) shouldBe Monday
       Enum.fromInt[WeekDay](2) shouldBe Tuesday
       Enum.fromInt[WeekDay](3) shouldBe Wednesday

--- a/src/test/scala/pbdirect/EnumSpec.scala
+++ b/src/test/scala/pbdirect/EnumSpec.scala
@@ -1,0 +1,39 @@
+package pbdirect
+
+import org.scalatest.{ Matchers, WordSpecLike }
+
+class EnumSpec extends WordSpecLike with Matchers {
+
+  sealed trait WeekDay  extends Pos
+  case object Monday    extends WeekDay with Pos._1
+  case object Tuesday   extends WeekDay with Pos._2
+  case object Wednesday extends WeekDay with Pos._3
+  case object Thursday  extends WeekDay with Pos._4
+  case object Friday    extends WeekDay with Pos._5
+  case object Saturday  extends WeekDay with Pos._6
+  case object Sunday    extends WeekDay with Pos._7
+
+  "Enum" should {
+    "list values in declared order" in {
+      Enum.values[WeekDay] shouldBe Monday :: Tuesday :: Wednesday :: Thursday :: Friday :: Saturday :: Sunday :: Nil
+    }
+    "get correct position for a value" in {
+      Enum.toInt[WeekDay](Monday)    shouldBe 1
+      Enum.toInt[WeekDay](Tuesday)   shouldBe 2
+      Enum.toInt[WeekDay](Wednesday) shouldBe 3
+      Enum.toInt[WeekDay](Thursday)  shouldBe 4
+      Enum.toInt[WeekDay](Friday)    shouldBe 5
+      Enum.toInt[WeekDay](Saturday)  shouldBe 6
+      Enum.toInt[WeekDay](Sunday)    shouldBe 7
+    }
+    "get the correct value for a position" in {
+      Enum.fromInt[WeekDay](1) shouldBe Monday
+      Enum.fromInt[WeekDay](2) shouldBe Tuesday
+      Enum.fromInt[WeekDay](3) shouldBe Wednesday
+      Enum.fromInt[WeekDay](4) shouldBe Thursday
+      Enum.fromInt[WeekDay](5) shouldBe Friday
+      Enum.fromInt[WeekDay](6) shouldBe Saturday
+      Enum.fromInt[WeekDay](7) shouldBe Sunday
+    }
+  }
+}

--- a/src/test/scala/pbdirect/PBReaderSpec.scala
+++ b/src/test/scala/pbdirect/PBReaderSpec.scala
@@ -34,6 +34,16 @@ class PBReaderSpec extends WordSpecLike with Matchers {
       val bytes = Array[Byte](10, 5, 72, 101, 108, 108, 111)
       bytes.pbTo[StringMessage] shouldBe StringMessage(Some("Hello"))
     }
+    "read an enum from Protobuf" in {
+      sealed trait Grade extends Pos
+      case object GradeA extends Grade with Pos._1
+      case object GradeB extends Grade with Pos._2
+      case class GradeMessage(value: Option[Grade])
+      val bytesA = Array[Byte](8, 1)
+      val bytesB = Array[Byte](8, 2)
+      bytesA.pbTo[GradeMessage] shouldBe GradeMessage(Some(GradeA))
+      bytesB.pbTo[GradeMessage] shouldBe GradeMessage(Some(GradeB))
+    }
     "read a required field from Protobuf" in {
       case class RequiredMessage(value: Int)
       val bytes = Array[Byte](8 , 5)

--- a/src/test/scala/pbdirect/PBWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBWriterSpec.scala
@@ -36,6 +36,16 @@ class PBWriterSpec extends WordSpecLike with Matchers {
       val message = StringMessage(Some("Hello"))
       message.toPB shouldBe Array[Byte](10, 5, 72, 101, 108, 108, 111)
     }
+    "write an enum to Protobuf" in {
+      sealed trait Grade extends Pos
+      case object GradeA extends Grade with Pos._1
+      case object GradeB extends Grade with Pos._2
+      case class GradeMessage(value: Option[Grade])
+      val messageA = GradeMessage(Some(GradeA))
+      val messageB = GradeMessage(Some(GradeB))
+      messageA.toPB shouldBe Array[Byte](8, 1)
+      messageB.toPB shouldBe Array[Byte](8, 2)
+    }
     "write a required field to Protobuf" in {
       case class RequiredMessage(value: Int)
       val message = RequiredMessage(5)

--- a/src/test/scala/pbdirect/PosSpec.scala
+++ b/src/test/scala/pbdirect/PosSpec.scala
@@ -16,12 +16,12 @@ class PosSpec extends WordSpecLike with Matchers {
     new _61{}, new _62{}, new _63{}, new _64{}, new _65{}, new _66{}, new _67{}, new _68{}, new _69{}, new _70{},
     new _80{}, new _79{}, new _78{}, new _77{}, new _76{}, new _75{}, new _74{}, new _73{}, new _72{}, new _71{},
     new _81{}, new _82{}, new _83{}, new _84{}, new _85{}, new _86{}, new _87{}, new _88{}, new _89{}, new _90{},
-    new _99{}, new _98{}, new _97{}, new _96{}, new _95{}, new _94{}, new _93{}, new _92{}, new _91{}
+    new _99{}, new _98{}, new _97{}, new _96{}, new _95{}, new _94{}, new _93{}, new _92{}, new _91{}, new _0{}
   )
 
   "Pos" should {
     "be sortable" in {
-      pos.sorted.map(_._pos) shouldBe (1 to 99)
+      pos.sorted.map(_._pos) shouldBe (0 to 99)
     }
   }
 

--- a/src/test/scala/pbdirect/PosSpec.scala
+++ b/src/test/scala/pbdirect/PosSpec.scala
@@ -1,0 +1,28 @@
+package pbdirect
+
+import org.scalatest.{ Matchers, WordSpecLike }
+
+class PosSpec extends WordSpecLike with Matchers {
+
+  import Pos._
+
+  val pos = List(
+    new _1{}, new _2{}, new _3{}, new _4{}, new _5{}, new _6{}, new _7{}, new _8{}, new _9{}, new _10{},
+    new _20{}, new _19{}, new _18{}, new _17{}, new _16{}, new _15{}, new _14{}, new _13{}, new _12{}, new _11{},
+    new _21{}, new _22{}, new _23{}, new _24{}, new _25{}, new _26{}, new _27{}, new _28{}, new _29{}, new _30{},
+    new _40{}, new _39{}, new _38{}, new _37{}, new _36{}, new _35{}, new _34{}, new _33{}, new _32{}, new _31{},
+    new _41{}, new _42{}, new _43{}, new _44{}, new _45{}, new _46{}, new _47{}, new _48{}, new _49{}, new _50{},
+    new _60{}, new _59{}, new _58{}, new _57{}, new _56{}, new _55{}, new _54{}, new _53{}, new _52{}, new _51{},
+    new _61{}, new _62{}, new _63{}, new _64{}, new _65{}, new _66{}, new _67{}, new _68{}, new _69{}, new _70{},
+    new _80{}, new _79{}, new _78{}, new _77{}, new _76{}, new _75{}, new _74{}, new _73{}, new _72{}, new _71{},
+    new _81{}, new _82{}, new _83{}, new _84{}, new _85{}, new _86{}, new _87{}, new _88{}, new _89{}, new _90{},
+    new _99{}, new _98{}, new _97{}, new _96{}, new _95{}, new _94{}, new _93{}, new _92{}, new _91{}
+  )
+
+  "Pos" should {
+    "be sortable" in {
+      pos.sorted.map(_._pos) shouldBe (1 to 99)
+    }
+  }
+
+}


### PR DESCRIPTION
Enumerations are encoded in protobuf using the position of the value in the enum.

Scala enums are not supported as they aren't supported by Shapeless's `Generic`. Instead enums can be defined using a sealed trait and case objects.