### PR TITLE
Read/Write classes with an Array[Byte] field

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In order to use PBDirect you need to add the following lines to your `build.sbt`
 ```scala
 resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
 
-libraryDependencies += "beyondthelines" %% "pbdirect" % "0.0.0"
+libraryDependencies += "beyondthelines" %% "pbdirect" % "0.0.1"
 ```
 
 ## Dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "pbdirect"
 
-version := "0.0.0"
+version := "0.0.1"
 
 scalaVersion := "2.12.2"
 

--- a/src/main/scala/pbdirect/PBWriter.scala
+++ b/src/main/scala/pbdirect/PBWriter.scala
@@ -75,6 +75,10 @@ trait PBWriterImplicits extends LowPriorityPBWriterImplicits {
     override def writeTo(index: Int, value: String, out: CodedOutputStream): Unit =
       out.writeString(index, value)
   }
+  implicit object BytesWriter extends PBWriter[Array[Byte]] {
+    override def writeTo(index: Int, value: Array[Byte], out: CodedOutputStream): Unit =
+      out.writeByteArray(index, value)
+  }
   implicit def functorWriter[F[_], A](implicit functor: Functor[F], writer: PBWriter[A]): PBWriter[F[A]] =
     new PBWriter[F[A]] {
       override def writeTo(index: Int, value: F[A], out: CodedOutputStream): Unit = {

--- a/src/test/scala/pbdirect/PBReaderSpec.scala
+++ b/src/test/scala/pbdirect/PBReaderSpec.scala
@@ -16,8 +16,8 @@ class PBReaderSpec extends WordSpecLike with Matchers {
     }
     "read a Long from Protobuf" in {
       case class LongMessage(value: Option[Long])
-      val bytes = Array[Byte](8, -128, -128, -128, -128, -8, -1, -1, -1, -1, 1)
-      bytes.pbTo[LongMessage] shouldBe LongMessage(Some(Int.MaxValue + 1))
+      val bytes = Array[Byte](8, -128, -128, -128, -128, 8)
+      bytes.pbTo[LongMessage] shouldBe LongMessage(Some(Int.MaxValue.toLong + 1))
     }
     "read a Float from Protobuf" in {
       case class FloatMessage(value: Option[Float])
@@ -33,6 +33,11 @@ class PBReaderSpec extends WordSpecLike with Matchers {
       case class StringMessage(value: Option[String])
       val bytes = Array[Byte](10, 5, 72, 101, 108, 108, 111)
       bytes.pbTo[StringMessage] shouldBe StringMessage(Some("Hello"))
+    }
+    "read bytes from Protobuf" in {
+      case class BytesMessage(value: Option[Array[Byte]])
+      val bytes = Array[Byte](10, 5, 72, 101, 108, 108, 111)
+      bytes.pbTo[BytesMessage].value.get shouldBe Array[Byte](72, 101, 108, 108, 111)
     }
     "read an enum from Protobuf" in {
       sealed trait Grade extends Pos

--- a/src/test/scala/pbdirect/PBWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBWriterSpec.scala
@@ -18,8 +18,8 @@ class PBWriterSpec extends WordSpecLike with Matchers {
     }
     "write a Long to Protobuf" in {
       case class LongMessage(value: Option[Long])
-      val message = LongMessage(Some(Int.MaxValue + 1))
-      message.toPB shouldBe Array[Byte](8, -128, -128, -128, -128, -8, -1, -1, -1, -1, 1)
+      val message = LongMessage(Some(Int.MaxValue.toLong + 1))
+      message.toPB shouldBe Array[Byte](8, -128, -128, -128, -128, 8)
     }
     "write a Float to Protobuf" in {
       case class FloatMessage(value: Option[Float])
@@ -35,6 +35,11 @@ class PBWriterSpec extends WordSpecLike with Matchers {
       case class StringMessage(value: Option[String])
       val message = StringMessage(Some("Hello"))
       message.toPB shouldBe Array[Byte](10, 5, 72, 101, 108, 108, 111)
+    }
+    "write bytes to Protobuf" in {
+      case class BytesMessage(value: Array[Byte])
+      val message = BytesMessage(Array[Byte](8, 4))
+      message.toPB shouldBe Array[Byte](10, 2, 8, 4)
     }
     "write an enum to Protobuf" in {
       sealed trait Grade extends Pos


### PR DESCRIPTION
Support for field of type `Array[Byte]` was missing.

*Note*: Still some implicits resolution issues when the field is optional (i.e. not wrapped into an `Option`)