### PR TITLE
PBExtractor implicit resolution issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In order to use PBDirect you need to add the following lines to your `build.sbt`
 ```scala
 resolvers += Resolver.bintrayRepo("beyondthelines", "maven")
 
-libraryDependencies += "beyondthelines" %% "pbdirect" % "0.0.1"
+libraryDependencies += "beyondthelines" %% "pbdirect" % "0.0.2"
 ```
 
 ## Dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "pbdirect"
 
-version := "0.0.1"
+version := "0.0.2"
 
 scalaVersion := "2.12.2"
 


### PR DESCRIPTION
Private objects don't play well with implicit resolution.
Make PBExtractor public to solve this issue.