### PR TITLE
Add support for scala enumeration

### DIFF
--- a/src/main/scala/pbdirect/Enum.scala
+++ b/src/main/scala/pbdirect/Enum.scala
@@ -4,8 +4,8 @@ import shapeless.{ :+:, CNil, Coproduct, Generic, Witness }
 
 object Enum {
   def values[T](implicit v: Values[T], ord: Ordering[T]): Seq[T] = v.apply.sorted
-  def fromInt[T](index: Int)(implicit v: Values[T], ord: Ordering[T]): T = values.apply(index - 1)
-  def toInt[T](a: T)(implicit v: Values[T], ord: Ordering[T]): Int = values.indexOf(a) + 1
+  def fromInt[T](index: Int)(implicit v: Values[T], ord: Ordering[T]): T = values.apply(index)
+  def toInt[T](a: T)(implicit v: Values[T], ord: Ordering[T]): Int = values.indexOf(a)
 
   trait Values[T] {
     def apply: List[T]

--- a/src/main/scala/pbdirect/PBWriter.scala
+++ b/src/main/scala/pbdirect/PBWriter.scala
@@ -96,6 +96,11 @@ trait PBWriterImplicits extends LowPriorityPBWriterImplicits {
       override def writeTo(index: Int, value: E, out: CodedOutputStream): Unit =
         out.writeInt32(index, Enum.toInt(value))
     }
+  implicit def enumerationWriter[E <: Enumeration#Value]: PBWriter[E] =
+    new PBWriter[E] {
+      override def writeTo(index: Int, value: E, out: CodedOutputStream): Unit =
+        out.writeInt32(index, value.id)
+    }
 }
 
 object PBWriter extends PBWriterImplicits

--- a/src/test/scala/pbdirect/EnumSpec.scala
+++ b/src/test/scala/pbdirect/EnumSpec.scala
@@ -18,22 +18,22 @@ class EnumSpec extends WordSpecLike with Matchers {
       Enum.values[WeekDay] shouldBe Monday :: Tuesday :: Wednesday :: Thursday :: Friday :: Saturday :: Sunday :: Nil
     }
     "get correct position for a value" in {
-      Enum.toInt[WeekDay](Monday)    shouldBe 1
-      Enum.toInt[WeekDay](Tuesday)   shouldBe 2
-      Enum.toInt[WeekDay](Wednesday) shouldBe 3
-      Enum.toInt[WeekDay](Thursday)  shouldBe 4
-      Enum.toInt[WeekDay](Friday)    shouldBe 5
-      Enum.toInt[WeekDay](Saturday)  shouldBe 6
-      Enum.toInt[WeekDay](Sunday)    shouldBe 7
+      Enum.toInt[WeekDay](Monday)    shouldBe 0
+      Enum.toInt[WeekDay](Tuesday)   shouldBe 1
+      Enum.toInt[WeekDay](Wednesday) shouldBe 2
+      Enum.toInt[WeekDay](Thursday)  shouldBe 3
+      Enum.toInt[WeekDay](Friday)    shouldBe 4
+      Enum.toInt[WeekDay](Saturday)  shouldBe 5
+      Enum.toInt[WeekDay](Sunday)    shouldBe 6
     }
     "get correct value for a position" in {
-      Enum.fromInt[WeekDay](1) shouldBe Monday
-      Enum.fromInt[WeekDay](2) shouldBe Tuesday
-      Enum.fromInt[WeekDay](3) shouldBe Wednesday
-      Enum.fromInt[WeekDay](4) shouldBe Thursday
-      Enum.fromInt[WeekDay](5) shouldBe Friday
-      Enum.fromInt[WeekDay](6) shouldBe Saturday
-      Enum.fromInt[WeekDay](7) shouldBe Sunday
+      Enum.fromInt[WeekDay](0) shouldBe Monday
+      Enum.fromInt[WeekDay](1) shouldBe Tuesday
+      Enum.fromInt[WeekDay](2) shouldBe Wednesday
+      Enum.fromInt[WeekDay](3) shouldBe Thursday
+      Enum.fromInt[WeekDay](4) shouldBe Friday
+      Enum.fromInt[WeekDay](5) shouldBe Saturday
+      Enum.fromInt[WeekDay](6) shouldBe Sunday
     }
   }
 }

--- a/src/test/scala/pbdirect/PBReaderSpec.scala
+++ b/src/test/scala/pbdirect/PBReaderSpec.scala
@@ -39,13 +39,23 @@ class PBReaderSpec extends WordSpecLike with Matchers {
       val bytes = Array[Byte](10, 5, 72, 101, 108, 108, 111)
       bytes.pbTo[BytesMessage].value.get shouldBe Array[Byte](72, 101, 108, 108, 111)
     }
+    "read an enumeration from Protobuf" in {
+      case object Grade extends Enumeration {
+        val GradeA, GradeB = Value
+      }
+      val bytesA = Array[Byte](8, 0)
+      val bytesB = Array[Byte](8, 1)
+      case class GradeMessage(value: Option[Grade.Value])
+      bytesA.pbTo[GradeMessage] shouldBe GradeMessage(Some(Grade.GradeA))
+      bytesB.pbTo[GradeMessage] shouldBe GradeMessage(Some(Grade.GradeB))
+    }
     "read an enum from Protobuf" in {
       sealed trait Grade extends Pos
-      case object GradeA extends Grade with Pos._1
-      case object GradeB extends Grade with Pos._2
+      case object GradeA extends Grade with Pos._0
+      case object GradeB extends Grade with Pos._1
       case class GradeMessage(value: Option[Grade])
-      val bytesA = Array[Byte](8, 1)
-      val bytesB = Array[Byte](8, 2)
+      val bytesA = Array[Byte](8, 0)
+      val bytesB = Array[Byte](8, 1)
       bytesA.pbTo[GradeMessage] shouldBe GradeMessage(Some(GradeA))
       bytesB.pbTo[GradeMessage] shouldBe GradeMessage(Some(GradeB))
     }

--- a/src/test/scala/pbdirect/PBWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBWriterSpec.scala
@@ -41,15 +41,23 @@ class PBWriterSpec extends WordSpecLike with Matchers {
       val message = BytesMessage(Array[Byte](8, 4))
       message.toPB shouldBe Array[Byte](10, 2, 8, 4)
     }
+    "write an enumeration to Protobuf" in {
+      object Grade extends Enumeration {
+        val GradeA, GradeB = Value
+      }
+      case class EnumMessage(value: Grade.Value)
+      val message = EnumMessage(Grade.GradeB)
+      message.toPB shouldBe Array[Byte](8, 1)
+    }
     "write an enum to Protobuf" in {
       sealed trait Grade extends Pos
-      case object GradeA extends Grade with Pos._1
-      case object GradeB extends Grade with Pos._2
+      case object GradeA extends Grade with Pos._0
+      case object GradeB extends Grade with Pos._1
       case class GradeMessage(value: Option[Grade])
       val messageA = GradeMessage(Some(GradeA))
       val messageB = GradeMessage(Some(GradeB))
-      messageA.toPB shouldBe Array[Byte](8, 1)
-      messageB.toPB shouldBe Array[Byte](8, 2)
+      messageA.toPB shouldBe Array[Byte](8, 0)
+      messageB.toPB shouldBe Array[Byte](8, 1)
     }
     "write a required field to Protobuf" in {
       case class RequiredMessage(value: Int)


### PR DESCRIPTION
It's actually possible to get a `Generic` for a case object so by making sure that a scala enum is declared inside a case object it's actually possible to have a writer/reader available.

```scala
case object Days extends Enumeration {
  val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
}

case class Message(day: Days.Value)

Message(Days.Wed).toPB // serialises to [8, 2]
```
 