### PR TITLE
Fix diverging implicit resolution

### DIFF
--- a/src/main/scala/pbdirect/PBReader.scala
+++ b/src/main/scala/pbdirect/PBReader.scala
@@ -71,10 +71,10 @@ trait LowPriorityPBReaderImplicits extends LowerPriorityPBReaderImplicits {
   }
   implicit def prodReader[A, R <: HList](implicit
     gen: Generic.Aux[A, R],
-    repr: PBReader[R],
+    repr: Lazy[PBReader[R]],
     reader: PBReader[List[Array[Byte]]]
   ): PBReader[List[A]] = instance { (index: Int, bytes: Array[Byte]) =>
-    reader.read(index, bytes).map { bs => gen.from(repr.read(1, bs)) }
+    reader.read(index, bytes).map { bs => gen.from(repr.value.read(1, bs)) }
   }
   implicit def enumReader[A](implicit
     values: Enum.Values[A],

--- a/src/main/scala/pbdirect/PBWriter.scala
+++ b/src/main/scala/pbdirect/PBWriter.scala
@@ -23,11 +23,11 @@ trait LowPriorityPBWriterImplicits {
       head.writeTo(index, value.head, out)
       tail.value.writeTo(index + 1, value.tail, out)
     }
-  implicit def prodWriter[A, R <: HList](implicit gen: Generic.Aux[A, R], writer: PBWriter[R]): PBWriter[A] =
+  implicit def prodWriter[A, R <: HList](implicit gen: Generic.Aux[A, R], writer: Lazy[PBWriter[R]]): PBWriter[A] =
     instance { (index: Int, value: A, out: CodedOutputStream) =>
       val buffer = new ByteArrayOutputStream()
       val pbOut = CodedOutputStream.newInstance(buffer)
-      writer.writeTo(1, gen.to(value), pbOut)
+      writer.value.writeTo(1, gen.to(value), pbOut)
       pbOut.flush()
       out.writeByteArray(index, buffer.toByteArray)
     }

--- a/src/test/scala/pbdirect/PBReaderSpec.scala
+++ b/src/test/scala/pbdirect/PBReaderSpec.scala
@@ -104,5 +104,14 @@ class PBReaderSpec extends WordSpecLike with Matchers {
       intBytes.pbTo[Message] shouldBe IntMessage(Some(5))
       stringBytes.pbTo[Message] shouldBe StringMessage(Some("Hello"))
     }
+    "read a message with repeated nested message from Protobuf" in {
+      case class Metric(name: String, service: String, node: String, value: Float, count: Int)
+      case class Metrics(metrics: List[Metric])
+      val message = Metrics(
+        Metric("metric", "microservices", "node", 12F, 12345) :: Nil
+      )
+      val bytes = Array[Byte](10, 37, 10, 6, 109, 101, 116, 114, 105, 99, 18, 13, 109, 105, 99, 114, 111, 115, 101, 114, 118, 105, 99, 101, 115, 26, 4, 110, 111, 100, 101, 37, 0, 0, 64, 65, 40, -71, 96)
+      bytes.pbTo[Metrics] shouldBe message
+    }
   }
 }

--- a/src/test/scala/pbdirect/PBWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBWriterSpec.scala
@@ -104,5 +104,13 @@ class PBWriterSpec extends WordSpecLike with Matchers {
       intMessage.toPB shouldBe Array[Byte](8, 5)
       stringMessage.toPB shouldBe Array[Byte](10, 5, 72, 101, 108, 108, 111)
     }
+    "write a message with repeated nested message in Protobuf" in {
+      case class Metric(metric: String, microservice: String, node: String, value: Float, count: Int)
+      case class Metrics(metrics: List[Metric])
+      val message = Metrics(
+        Metric("metric", "microservices", "node", 12F, 12345) :: Nil
+      )
+      message.toPB shouldBe Array[Byte](10, 37, 10, 6, 109, 101, 116, 114, 105, 99, 18, 13, 109, 105, 99, 114, 111, 115, 101, 114, 118, 105, 99, 101, 115, 26, 4, 110, 111, 100, 101, 37, 0, 0, 64, 65, 40, -71, 96)
+    }
   }
 }


### PR DESCRIPTION
Wrap implicit PBWriter and implicit PBReader into shapeless Lazy to avoid compiler issue with diverging implicit resolution.

Fixes https://github.com/btlines/pbdirect/issues/9