### PR TITLE
Update cats to 1.0.0-MF

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "pbdirect"
 
-version := "0.0.4"
+version := "0.0.5"
 
 scalaVersion := "2.12.2"
 
@@ -8,7 +8,7 @@ crossScalaVersions := Seq("2.11.11", "2.12.2")
 
 libraryDependencies ++= Seq(
   "com.chuusai"         %% "shapeless"     % "2.3.2",
-  "org.typelevel"       %% "cats"          % "0.9.0",
+  "org.typelevel"       %% "cats-core"     % "1.0.0-MF",
   "com.google.protobuf" %  "protobuf-java" % "3.2.0",
   "org.scalatest"       %% "scalatest"     % "3.0.1" % Test
 )


### PR DESCRIPTION
I just updated the cats version to 1.0.0-MF. 

After take a look to the code, the only file whose uses something of cats is `PBWriter`. Here we are using cats to create one implicit for Functors.

I just checked that all the test pass properly.

It resolves #11 