### PR TITLE
Added Implicits for Date and Wrapped Array Types

### DIFF
--- a/src/main/scala/pbdirect/PBReader.scala
+++ b/src/main/scala/pbdirect/PBReader.scala
@@ -1,8 +1,11 @@
 package pbdirect
 
+import java.util.Date
+
 import com.google.protobuf.CodedInputStream
 import shapeless.{ :+:, ::, CNil, Coproduct, Generic, HList, HNil, Inl, Inr, Lazy }
 
+import scala.collection.mutable.WrappedArray
 import scala.util.Try
 
 trait PBExtractor[A] {
@@ -29,6 +32,12 @@ object PBExtractor {
   }
   implicit object BytesExtractor extends PBExtractor[Array[Byte]] {
     override def extract(input: CodedInputStream): Array[Byte] = input.readByteArray()
+  }
+  implicit object DateExtractor extends PBExtractor[Date] {
+    override def extract(input: CodedInputStream): Date = new Date(input.readInt64())
+  }
+  implicit object WrappedBytesExtractor extends PBExtractor[WrappedArray[Byte]] {
+    override def extract(input: CodedInputStream): WrappedArray[Byte] = input.readByteArray()
   }
 }
 

--- a/src/test/scala/pbdirect/PBReaderSpec.scala
+++ b/src/test/scala/pbdirect/PBReaderSpec.scala
@@ -1,6 +1,10 @@
 package pbdirect
 
+import java.util.Date
+
 import org.scalatest.{ Matchers, WordSpecLike }
+
+import scala.collection.mutable.WrappedArray
 
 class PBReaderSpec extends WordSpecLike with Matchers {
   "PBReader" should {
@@ -38,6 +42,16 @@ class PBReaderSpec extends WordSpecLike with Matchers {
       case class BytesMessage(value: Option[Array[Byte]])
       val bytes = Array[Byte](10, 5, 72, 101, 108, 108, 111)
       bytes.pbTo[BytesMessage].value.get shouldBe Array[Byte](72, 101, 108, 108, 111)
+    }
+    "read a Date from Protobuf" in {
+      case class DateMessage(value: Option[Date])
+      val bytes = Array[Byte](8, -128, -128, -128, -128, 8)
+      bytes.pbTo[DateMessage] shouldBe DateMessage(Some(new Date(Int.MaxValue.toLong + 1)))
+    }
+    "read a Wrappedarraybytes from Protobuf" in {
+      case class WrappedArrayMessage(value: Option[WrappedArray[Byte]])
+      val bytes = Array[Byte](10, 1, 8)
+      bytes.pbTo[WrappedArrayMessage].value.get shouldBe Array(8)
     }
     "read an enumeration from Protobuf" in {
       case object Grade extends Enumeration {

--- a/src/test/scala/pbdirect/PBWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBWriterSpec.scala
@@ -1,8 +1,12 @@
 package pbdirect
 
+import java.util.Date
+
 import cats.instances.option._
 import cats.instances.list._
 import org.scalatest.{ Matchers, WordSpecLike }
+
+import scala.collection.mutable.WrappedArray
 
 class PBWriterSpec extends WordSpecLike with Matchers {
   "PBWriter" should {
@@ -40,6 +44,16 @@ class PBWriterSpec extends WordSpecLike with Matchers {
       case class BytesMessage(value: Array[Byte])
       val message = BytesMessage(Array[Byte](8, 4))
       message.toPB shouldBe Array[Byte](10, 2, 8, 4)
+    }
+    "write a Date to Protobuf" in {
+      case class DateMessage(value: Option[Date])
+      val message = DateMessage(Some(new Date(Int.MaxValue.toLong + 1)))
+      message.toPB shouldBe Array[Byte](8, -128, -128, -128, -128, 8)
+    }
+    "write a WrappedArrayBytes to Protobuf" in {
+      case class WrappedArrayMessage(value: WrappedArray[Byte])
+      val message = WrappedArrayMessage(Array(8.toByte))
+      message.toPB shouldBe Array[Byte](10, 1, 8)
     }
     "write an enumeration to Protobuf" in {
       object Grade extends Enumeration {


### PR DESCRIPTION
@btlines : Earlier there was an absence of implicit for the Date and Wrapped Array types due to which in case a case class had following fields there was a compilation error as the implicit reader and writer could not be found. 

So, basically in this PR, the implicit PBReaders and PBWriter objects for both the data types along with the test cases are added so that they don't have to code individually.
I checked that all the test pass properly after adding the code and the test cases.
Hope it makes sense. Thanks.