### PR TITLE
Add extensibility support for custom types

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import pbdirect._
 
 ### Schema definition
 
-PBDirect serialises case classes into protobuf and there is no need for a .proto shema definition file.
+PBDirect serialises case classes into protobuf and there is no need for a .proto schema definition file.
 
 ```scala
 case class MyMessage(
@@ -90,6 +90,40 @@ This method is added implicitly on all `Array[Byte]` by importing `pbdirect._`.
 ```scala
 val bytes: Array[Byte] = Array[Byte](8, 123, 18, 5, 72, 101, 108, 108, 111, 24, 1, 32, 2, 40, 3, 48, 4)
 val message = bytes.pbTo[MyMessage]
+```
+
+## Extension
+
+You might want to define your own formats for unsupported types.
+E.g. to add a format to write `java.time.Instant` you can do:
+
+```scala
+import java.time.Instant
+import cats.syntax.invariant._
+
+implicit val instantFormat: PBFormat[Instant] =
+  PBFormat[Long].imap(Instant.ofEpochMilli)(_.toEpochMilli)
+```
+
+If you only need a reader you can map over an existing `PBReader`
+
+```scala
+import java.time.Instant
+import cats.syntax.functor._
+
+implicit val instantReader: PBReader[Instant] =
+  PBReader[Long].map(Instant.ofEpochMilli)
+```
+
+And for a writer you simply contramap over it:
+
+```scala
+import java.time.Instant
+import cats.syntax.contravariant._
+
+implicit val instantWriter: PBWriter[Instant] =
+  PBWriter[Long].contramap(_.toEpochMilli)
+  )
 ```
 
 ### More information

--- a/src/main/scala/pbdirect/PBFormat.scala
+++ b/src/main/scala/pbdirect/PBFormat.scala
@@ -1,0 +1,27 @@
+package pbdirect
+
+import cats.Functor
+import cats.functor.{Contravariant, Invariant}
+import com.google.protobuf.CodedOutputStream
+
+sealed trait PBFormat[A] extends PBReader[A] with PBWriter[A]
+
+trait PBFormatImplicits {
+  implicit object InvariantFormat extends Invariant[PBFormat] {
+    override def imap[A, B](format: PBFormat[A])(f: A => B)(g: B => A): PBFormat[B] =
+      PBFormat[B](
+        Functor[PBReader].map(format)(f),
+        Contravariant[PBWriter].contramap(format)(g)
+      )
+  }
+}
+
+object PBFormat extends PBFormatImplicits {
+  def apply[A](implicit reader: PBReader[A], writer: PBWriter[A]): PBFormat[A] =
+    new PBFormat[A] {
+      override def read(index: Int, bytes: Array[Byte]): A =
+        reader.read(index, bytes)
+      override def writeTo(index: Int, value: A, out: CodedOutputStream): Unit =
+        writer.writeTo(index, value, out)
+    }
+}

--- a/src/main/scala/pbdirect/PBReader.scala
+++ b/src/main/scala/pbdirect/PBReader.scala
@@ -1,7 +1,8 @@
 package pbdirect
 
+import cats.Functor
 import com.google.protobuf.CodedInputStream
-import shapeless.{ :+:, ::, CNil, Coproduct, Generic, HList, HNil, Inl, Inr, Lazy }
+import shapeless.{:+:, ::, CNil, Coproduct, Generic, HList, HNil, Inl, Inr, Lazy}
 
 import scala.util.Try
 
@@ -119,6 +120,15 @@ trait PBReaderImplicits extends LowPriorityPBReaderImplicits {
     instance { (index: Int, bytes: Array[Byte]) =>
       reader.read(index, bytes).toMap
     }
+
+  implicit object FunctorReader extends Functor[PBReader] {
+    override def map[A, B](reader: PBReader[A])(f: A => B): PBReader[B] =
+      instance[B] { (index: Int, bytes: Array[Byte]) =>
+        f(reader.read(index, bytes))
+      }
+  }
 }
 
-object PBReader extends PBReaderImplicits
+object PBReader extends PBReaderImplicits {
+  def apply[A : PBReader]: PBReader[A] = implicitly
+}

--- a/src/test/scala/pbdirect/PBFormatSpec.scala
+++ b/src/test/scala/pbdirect/PBFormatSpec.scala
@@ -1,0 +1,20 @@
+package pbdirect
+
+import org.scalatest.{Matchers, WordSpec}
+
+class PBFormatSpec extends WordSpec with Matchers {
+
+  "PBFormat" should {
+    "derived new instances using imap" in {
+      import java.time.Instant
+      import cats.syntax.invariant._
+      case class Message(instant: Instant)
+      implicit val instantFormat: PBFormat[Instant] = PBFormat[Long].imap(Instant.ofEpochMilli)(_.toEpochMilli)
+      val instant = Instant.ofEpochMilli(1499411227777L)
+      val bytes = Message(instant).toPB
+      bytes shouldBe Array[Byte](8, -127, -55, -2, -34, -47, 43)
+      bytes.pbTo[Message] shouldBe Message(instant)
+    }
+  }
+
+}

--- a/src/test/scala/pbdirect/PBReaderSpec.scala
+++ b/src/test/scala/pbdirect/PBReaderSpec.scala
@@ -113,5 +113,13 @@ class PBReaderSpec extends WordSpecLike with Matchers {
       val bytes = Array[Byte](10, 37, 10, 6, 109, 101, 116, 114, 105, 99, 18, 13, 109, 105, 99, 114, 111, 115, 101, 114, 118, 105, 99, 101, 115, 26, 4, 110, 111, 100, 101, 37, 0, 0, 64, 65, 40, -71, 96)
       bytes.pbTo[Metrics] shouldBe message
     }
+    "derive new instance using map" in {
+      import java.time.Instant
+      import cats.syntax.functor._
+      implicit val instantReader: PBReader[Instant] = PBReader[Long].map(Instant.ofEpochMilli)
+      case class Message(instant: Instant)
+      val instant = Instant.ofEpochMilli(1499411227777L)
+      Array[Byte](8, -127, -55, -2, -34, -47, 43).pbTo[Message] shouldBe Message(instant)
+    }
   }
 }

--- a/src/test/scala/pbdirect/PBWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBWriterSpec.scala
@@ -112,5 +112,13 @@ class PBWriterSpec extends WordSpecLike with Matchers {
       )
       message.toPB shouldBe Array[Byte](10, 37, 10, 6, 109, 101, 116, 114, 105, 99, 18, 13, 109, 105, 99, 114, 111, 115, 101, 114, 118, 105, 99, 101, 115, 26, 4, 110, 111, 100, 101, 37, 0, 0, 64, 65, 40, -71, 96)
     }
+    "derive new instance using contramap" in {
+      import java.time.Instant
+      import cats.syntax.contravariant._
+      case class Message(instant: Instant)
+      implicit val instantWriter: PBWriter[Instant] = PBWriter[Long].contramap(_.toEpochMilli)
+      val instant = Instant.ofEpochMilli(1499411227777L)
+      Message(instant).toPB shouldBe Array[Byte](8, -127, -55, -2, -34, -47, 43)
+    }
   }
 }


### PR DESCRIPTION
- Add PBFormat a combination of PBReader and PBWriter
- Use cats to provide extensibility methods to support custom types:
  - provide map to create new PBReader from existing ones
  - provide contramap to create new PBWriter from existing ones
  - provide imap to create new PBFormat from existing ones
- Update README