### PR TITLE
Fix diverging implicit expansion

### DIFF
--- a/src/main/scala/pbdirect/PBFormat.scala
+++ b/src/main/scala/pbdirect/PBFormat.scala
@@ -2,7 +2,7 @@ package pbdirect
 
 import cats.Functor
 import cats.{Contravariant, Invariant}
-import com.google.protobuf.CodedOutputStream
+import com.google.protobuf.{CodedInputStream, CodedOutputStream}
 
 sealed trait PBFormat[A] extends PBReader[A] with PBWriter[A]
 
@@ -19,8 +19,7 @@ trait PBFormatImplicits {
 object PBFormat extends PBFormatImplicits {
   def apply[A](implicit reader: PBReader[A], writer: PBWriter[A]): PBFormat[A] =
     new PBFormat[A] {
-      override def read(index: Int, bytes: Array[Byte]): A =
-        reader.read(index, bytes)
+      override def read(input: CodedInputStream): A = reader.read(input)
       override def writeTo(index: Int, value: A, out: CodedOutputStream): Unit =
         writer.writeTo(index, value, out)
     }

--- a/src/main/scala/pbdirect/PBReader.scala
+++ b/src/main/scala/pbdirect/PBReader.scala
@@ -1,104 +1,125 @@
 package pbdirect
 
+import java.io.ByteArrayOutputStream
+
 import cats.Functor
-import com.google.protobuf.CodedInputStream
+import com.google.protobuf.{CodedInputStream, CodedOutputStream}
 import shapeless.{:+:, ::, CNil, Coproduct, Generic, HList, HNil, Inl, Inr, Lazy}
 
 import scala.util.Try
 
-trait PBExtractor[A] {
-  def extract(input: CodedInputStream): A
-}
-object PBExtractor {
-  implicit object BooleanExtractor extends PBExtractor[Boolean] {
-    override def extract(input: CodedInputStream): Boolean = input.readBool()
-  }
-  implicit object IntExtractor extends PBExtractor[Int] {
-    override def extract(input: CodedInputStream): Int = input.readInt32()
-  }
-  implicit object LongExtractor extends PBExtractor[Long] {
-    override def extract(input: CodedInputStream): Long = input.readInt64()
-  }
-  implicit object FloatExtractor extends PBExtractor[Float] {
-    override def extract(input: CodedInputStream): Float = input.readFloat()
-  }
-  implicit object DoubleExtractor extends PBExtractor[Double] {
-    override def extract(input: CodedInputStream): Double = input.readDouble()
-  }
-  implicit object StringExtractor extends PBExtractor[String] {
-    override def extract(input: CodedInputStream): String = input.readString()
-  }
-  implicit object BytesExtractor extends PBExtractor[Array[Byte]] {
-    override def extract(input: CodedInputStream): Array[Byte] = input.readByteArray()
-  }
-}
-
 trait PBReader[A] {
-  def read(index: Int, bytes: Array[Byte]): A
+  def read(input: CodedInputStream): A
 }
-
 trait LowerPriorityPBReaderImplicits {
-  def instance[A](f: (Int, Array[Byte]) => A): PBReader[A] =
-    new PBReader[A] {
-      override def read(index: Int, bytes: Array[Byte]): A = f(index, bytes)
-    }
-  implicit object CNilReader extends PBReader[List[CNil]] {
-    override def read(index: Int, bytes: Array[Byte]): List[CNil] =
-      throw new UnsupportedOperationException("Can't read CNil")
-  }
-  implicit def cconsReader[H, T <: Coproduct](implicit
-    head: PBReader[List[H]],
-    tail: Lazy[PBReader[List[T]]]
-  ): PBReader[List[H :+: T]] = instance { (index: Int, bytes: Array[Byte]) =>
-    Try { head.read(index, bytes).map(Inl.apply) }  getOrElse tail.value.read(index, bytes).map(Inr.apply)
-  }
   implicit def coprodReader[A, R <: Coproduct](implicit
     gen: Generic.Aux[A, R],
-    parser: Lazy[PBReader[List[R]]]
-  ): PBReader[List[A]] = instance { (index: Int, bytes: Array[Byte]) =>
-    parser.value.read(index, bytes).map(gen.from)
+    repr: Lazy[PBParser[R]]
+  ): PBReader[A] = { (input: CodedInputStream) =>
+    val bytes = input.readByteArray()
+
+    // wraps the bytes into a protobuf single field message
+    val out = new ByteArrayOutputStream()
+    val pbOut = CodedOutputStream.newInstance(out)
+    pbOut.writeByteArray(1, bytes)
+    pbOut.flush()
+
+    gen.from(repr.value.parse(1, out.toByteArray))
   }
 }
+trait PBReaderImplicits extends LowerPriorityPBReaderImplicits {
 
-trait LowPriorityPBReaderImplicits extends LowerPriorityPBReaderImplicits {
-  implicit object HNilReader extends PBReader[HNil] {
-    override def read(index: Int, bytes: Array[Byte]): HNil = HNil
-  }
-  implicit def consReader[H, T <: HList](implicit
-    head: PBReader[H],
-    tail: Lazy[PBReader[T]]
-  ): PBReader[H :: T] = instance { (index: Int, bytes: Array[Byte]) =>
-    head.read(index, bytes) :: tail.value.read(index + 1, bytes)
-  }
   implicit def prodReader[A, R <: HList](implicit
     gen: Generic.Aux[A, R],
-    repr: Lazy[PBReader[R]],
-    reader: PBReader[List[Array[Byte]]]
-  ): PBReader[List[A]] = instance { (index: Int, bytes: Array[Byte]) =>
-    reader.read(index, bytes).map { bs => gen.from(repr.value.read(1, bs)) }
+    repr: Lazy[PBParser[R]]
+  ): PBReader[A] = { (input: CodedInputStream) =>
+    val bytes = input.readByteArray()
+    gen.from(repr.value.parse(1, bytes))
   }
+
   implicit def enumReader[A](implicit
     values: Enum.Values[A],
     ordering: Ordering[A],
-    reader: PBReader[List[Int]]
-  ): PBReader[List[A]] = instance { (index: Int, bytes: Array[Byte]) =>
-    reader.read(index, bytes).map(i => Enum.fromInt(i))
+    reader: PBReader[Int]
+  ): PBReader[A] = { (input: CodedInputStream) =>
+    Enum.fromInt[A](reader.read(input))
   }
   implicit def enumerationReader[E <: Enumeration](implicit
-    reader: PBReader[List[Int]],
+    reader: PBReader[Int],
     gen: Generic.Aux[E, HNil]
-  ): PBReader[List[E#Value]] = instance { (index: Int, bytes: Array[Byte]) =>
+  ): PBReader[E#Value] = { (input: CodedInputStream) =>
     val enum = gen.from(HNil)
-    reader.read(index, bytes).map(enum.apply)
+    enum(reader.read(input))
   }
-  implicit def requiredReader[A](implicit reader: PBReader[List[A]]): PBReader[A] =
-    instance { (index: Int, bytes: Array[Byte]) =>
-      reader.read(index, bytes).last
+}
+object PBReader extends PBReaderImplicits {
+  implicit object BooleanReader$ extends PBReader[Boolean] {
+    override def read(input: CodedInputStream): Boolean = input.readBool()
+  }
+  implicit object IntReader$ extends PBReader[Int] {
+    override def read(input: CodedInputStream): Int = input.readInt32()
+  }
+  implicit object LongReader$ extends PBReader[Long] {
+    override def read(input: CodedInputStream): Long = input.readInt64()
+  }
+  implicit object FloatReader$ extends PBReader[Float] {
+    override def read(input: CodedInputStream): Float = input.readFloat()
+  }
+  implicit object DoubleReader$ extends PBReader[Double] {
+    override def read(input: CodedInputStream): Double = input.readDouble()
+  }
+  implicit object StringReader$ extends PBReader[String] {
+    override def read(input: CodedInputStream): String = input.readString()
+  }
+  implicit object BytesReader$ extends PBReader[Array[Byte]] {
+    override def read(input: CodedInputStream): Array[Byte] = input.readByteArray()
+  }
+
+  def apply[A : PBReader]: PBReader[A] = implicitly
+
+  implicit object FunctorReader extends Functor[PBReader] {
+    override def map[A, B](reader: PBReader[A])(f: A => B): PBReader[B] = {
+      (input: CodedInputStream) =>f(reader.read(input))
     }
+  }
 }
 
-trait PBReaderImplicits extends LowPriorityPBReaderImplicits {
-  implicit def repeatedReader[A](implicit extractor: PBExtractor[A]): PBReader[List[A]] =
+trait PBParser[A] {
+  def parse(index: Int, bytes: Array[Byte]): A
+}
+
+trait LowPriorityPBParserImplicits {
+  def instance[A](f: (Int, Array[Byte]) => A): PBParser[A] = new PBParser[A] {
+    override def parse(index: Int, bytes: Array[Byte]): A = f(index, bytes)
+  }
+  implicit val hnilParser: PBParser[HNil] = instance {
+    (index: Int, bytes: Array[Byte]) => HNil
+  }
+  implicit def consParser[H, T <: HList](implicit
+    head: PBParser[H],
+    tail: Lazy[PBParser[T]]
+  ): PBParser[H :: T] = instance { (index: Int, bytes: Array[Byte]) =>
+    head.parse(index, bytes) :: tail.value.parse(index + 1, bytes)
+  }
+
+  implicit val cnilParser: PBParser[CNil] = instance {
+    (index: Int, bytes: Array[Byte]) =>
+      throw new UnsupportedOperationException("Can't read CNil")
+  }
+  implicit def cconsParser[H, T <: Coproduct](implicit
+    head: PBParser[H],
+    tail: Lazy[PBParser[T]]
+  ): PBParser[H :+: T] = instance { (index: Int, bytes: Array[Byte]) =>
+    Try {
+      Inl(head.parse(index, bytes))
+    } getOrElse {
+      Inr(tail.value.parse(index, bytes))
+    }
+  }
+}
+
+trait PBParserImplicits extends LowPriorityPBParserImplicits {
+  implicit def repeatedParser[A](implicit reader: PBReader[A]): PBParser[List[A]] =
     instance { (index: Int, bytes: Array[Byte]) =>
       val input = CodedInputStream.newInstance(bytes)
       var done = false
@@ -106,29 +127,34 @@ trait PBReaderImplicits extends LowPriorityPBReaderImplicits {
       while (!done) {
         input.readTag() match {
           case 0 => done = true
-          case tag if (tag >> 3) == index => as ::= extractor.extract(input)
+          case tag if (tag >> 3) == index => as ::= reader.read(input)
           case tag => input.skipField(tag)
         }
       }
       as.reverse
     }
-  implicit def optionalReader[A](implicit reader: PBReader[List[A]]): PBReader[Option[A]] =
+  implicit def requiredParser[A](implicit reader: PBReader[A]): PBParser[A] =
     instance { (index: Int, bytes: Array[Byte]) =>
-      reader.read(index, bytes).lastOption
-    }
-  implicit def mapReader[K, V](implicit reader: PBReader[List[(K, V)]]): PBReader[Map[K, V]] =
-    instance { (index: Int, bytes: Array[Byte]) =>
-      reader.read(index, bytes).toMap
-    }
-
-  implicit object FunctorReader extends Functor[PBReader] {
-    override def map[A, B](reader: PBReader[A])(f: A => B): PBReader[B] =
-      instance[B] { (index: Int, bytes: Array[Byte]) =>
-        f(reader.read(index, bytes))
+      val input = CodedInputStream.newInstance(bytes)
+      var done = false
+      var as: List[A] = Nil
+      while (!done) {
+        input.readTag() match {
+          case 0 => done = true
+          case tag if (tag >> 3) == index => as ::= reader.read(input)
+          case tag => input.skipField(tag)
+        }
       }
-  }
+      as.head
+    }
+  implicit def optionalParser[A](implicit parser: PBParser[List[A]]): PBParser[Option[A]] =
+    instance { (index: Int, bytes: Array[Byte]) =>
+      parser.parse(index, bytes).lastOption
+    }
+  implicit def mapParser[K, V](implicit parser: PBParser[List[(K, V)]]): PBParser[Map[K, V]] =
+    instance { (index: Int, bytes: Array[Byte]) =>
+      parser.parse(index, bytes).toMap
+    }
 }
 
-object PBReader extends PBReaderImplicits {
-  def apply[A : PBReader]: PBReader[A] = implicitly
-}
+object PBParser extends PBParserImplicits

--- a/src/main/scala/pbdirect/PBWriter.scala
+++ b/src/main/scala/pbdirect/PBWriter.scala
@@ -15,8 +15,8 @@ trait LowPriorityPBWriterImplicits {
     new PBWriter[A] {
       override def writeTo(index: Int, value: A, out: CodedOutputStream): Unit = f(index, value, out)
     }
-  implicit object HNilWriter extends PBWriter[HNil] {
-    override def writeTo(index: Int, value: HNil, out: CodedOutputStream): Unit = ()
+  implicit val hnilWriter: PBWriter[HNil] = instance {
+    (_: Int, _: HNil, _: CodedOutputStream) => ()
   }
   implicit def consWriter[H, T <: HList](implicit head: PBWriter[H], tail: Lazy[PBWriter[T]]): PBWriter[H :: T] =
     instance { (index: Int, value: H :: T, out: CodedOutputStream) =>
@@ -32,8 +32,8 @@ trait LowPriorityPBWriterImplicits {
       out.writeByteArray(index, buffer.toByteArray)
     }
 
-  implicit object CNilWriter extends PBWriter[CNil] {
-    override def writeTo(index: Int, value: CNil, out: CodedOutputStream): Unit = ()
+  implicit val cnilWriter: PBWriter[CNil] = instance {
+    (_: Int, _: CNil, _: CodedOutputStream) => throw new Exception("Can't write CNil")
   }
   implicit def cconsWriter[H, T <: Coproduct](implicit head: PBWriter[H], tail: PBWriter[T]): PBWriter[H :+: T] =
     instance { (index: Int, value: H :+: T, out: CodedOutputStream) =>

--- a/src/main/scala/pbdirect/package.scala
+++ b/src/main/scala/pbdirect/package.scala
@@ -3,7 +3,7 @@ import java.io.ByteArrayOutputStream
 import com.google.protobuf.{ CodedInputStream, CodedOutputStream }
 
 package object pbdirect {
-  implicit class PBWriterOps[A](a: A) {
+  implicit class PBWriterOps[A](private val a: A) extends AnyVal {
     def toPB(implicit writer: PBWriter[A]): Array[Byte] = {
       val out = new ByteArrayOutputStream()
       val pbOut = CodedOutputStream.newInstance(out)
@@ -16,14 +16,14 @@ package object pbdirect {
       input.readByteArray()
     }
   }
-  implicit class PBReaderOps(bytes: Array[Byte]) {
-    def pbTo[A](implicit reader: PBReader[A]): A = {
+  implicit class PBParserOps(private val bytes: Array[Byte]) extends AnyVal {
+    def pbTo[A](implicit reader: PBParser[A]): A = {
       // wraps the bytes into a protobuf single field message
       val out = new ByteArrayOutputStream()
       val pbOut = CodedOutputStream.newInstance(out)
       pbOut.writeByteArray(1, bytes)
       pbOut.flush()
-      reader.read(1, out.toByteArray)
+      reader.parse(1, out.toByteArray)
     }
   }
 }

--- a/src/test/scala/pbdirect/PBFormatSpec.scala
+++ b/src/test/scala/pbdirect/PBFormatSpec.scala
@@ -3,17 +3,26 @@ package pbdirect
 import org.scalatest.{Matchers, WordSpec}
 
 class PBFormatSpec extends WordSpec with Matchers {
+  import java.time.Instant
+  import cats.syntax.invariant._
+
+  implicit val instantFormat: PBFormat[Instant] = PBFormat[Long].imap(Instant.ofEpochMilli)(_.toEpochMilli)
 
   "PBFormat" should {
     "derived new instances using imap" in {
-      import java.time.Instant
-      import cats.syntax.invariant._
       case class Message(instant: Instant)
-      implicit val instantFormat: PBFormat[Instant] = PBFormat[Long].imap(Instant.ofEpochMilli)(_.toEpochMilli)
       val instant = Instant.ofEpochMilli(1499411227777L)
       val bytes = Message(instant).toPB
       bytes shouldBe Array[Byte](8, -127, -55, -2, -34, -47, 43)
       bytes.pbTo[Message] shouldBe Message(instant)
+    }
+    "derived optional instances using imap" in {
+      import cats.instances.option._
+      case class Message(instant: Option[Instant])
+      val instant = Instant.ofEpochMilli(1499411227777L)
+      val bytes = Message(Some(instant)).toPB
+      bytes shouldBe Array[Byte](8, -127, -55, -2, -34, -47, 43)
+      bytes.pbTo[Message] shouldBe Message(Some(instant))
     }
   }
 


### PR DESCRIPTION
When using PBReader derived instances for optional/repeated fields the compilation fails with a diverging implicits error.

Fix https://github.com/btlines/pbdirect/issues/18